### PR TITLE
Add a custom user agent string to each request

### DIFF
--- a/request_helpers.go
+++ b/request_helpers.go
@@ -83,13 +83,14 @@ func (client *Config) addHeaders(req *http.Request) {
 	if client.APIKey == "" {
 		log.Fatal("taxjar: missing `APIKey` field must be set on client")
 	}
+
 	req.Header.Add("Authorization", "Bearer "+client.APIKey)
-	req.Header.Add("Content-type", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", getUserAgent())
+
 	for key, val := range client.Headers {
-		val, _ := val.(string)
-		if key != "Authorization" && key != "Content-type" && key != "User-Agent" {
-			req.Header.Add(key, val)
+		if key = http.CanonicalHeaderKey(key); key != "Authorization" && key != "Content-Type" && key != "User-Agent" {
+			req.Header.Add(key, val.(string))
 		}
 	}
 }

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -1,12 +1,17 @@
 package taxjar
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -50,15 +55,40 @@ func (client *Config) url(endpoint string) string {
 	return fmt.Sprintf("%v/%v/%v", client.APIURL, client.APIVersion, endpoint)
 }
 
+func getUserAgent() string {
+	platform := runtime.GOOS
+	uname, err := exec.LookPath("uname")
+	if err == nil {
+		cmd := exec.Command(uname, "-a")
+		var out bytes.Buffer
+		cmd.Stderr = nil
+		cmd.Stdout = &out
+		err = cmd.Run()
+		if err == nil {
+			platform = strings.TrimSpace(out.String())
+		}
+	}
+
+	goVersion := runtime.Version()
+	re, _ := regexp.Compile(`go(.+)`)
+	matches := re.FindStringSubmatch(goVersion)
+	if len(matches) > 1 {
+		goVersion = fmt.Sprintf("%v", matches[1])
+	}
+
+	return fmt.Sprintf("TaxJar/Go (%v; %v; go %v) taxjar-go/%v", platform, runtime.GOARCH, goVersion, version)
+}
+
 func (client *Config) addHeaders(req *http.Request) {
 	if client.APIKey == "" {
 		log.Fatal("taxjar: missing `APIKey` field must be set on client")
 	}
 	req.Header.Add("Authorization", "Bearer "+client.APIKey)
 	req.Header.Add("Content-type", "application/json")
+	req.Header.Add("User-Agent", getUserAgent())
 	for key, val := range client.Headers {
 		val, _ := val.(string)
-		if key != "Authorization" && key != "Content-type" {
+		if key != "Authorization" && key != "Content-type" && key != "User-Agent" {
 			req.Header.Add(key, val)
 		}
 	}

--- a/test/Headers_test.go
+++ b/test/Headers_test.go
@@ -28,13 +28,36 @@ var _ = Describe("Request headers:", func() {
 		server.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", "/v2/categories"),
 			ghttp.VerifyContentType("application/json"),
-			ghttp.VerifyHeader(http.Header{
-				"Authorization": []string{"Bearer test123"},
-			}),
+			ghttp.VerifyHeader(http.Header{"Authorization": []string{"Bearer test123"}}),
+			func /* verifyUserAgent */ (w http.ResponseWriter, req *http.Request) {
+				userAgent := req.Header["User-Agent"][0]
+				Expect(userAgent).To(MatchRegexp(`^TaxJar/Go \(.*\) taxjar-go/\d+\.\d+\.\d+$`))
+			},
 		))
 		client.Categories()
+	})
 
-		userAgent := server.ReceivedRequests()[0].Header["User-Agent"][0]
-		Expect(userAgent).To(MatchRegexp(`^TaxJar/Go \(.*\) taxjar-go/\d+\.\d+\.\d+$`))
+	It("should not allow overwriting standard headers", func() {
+		server.AppendHandlers(ghttp.VerifyRequest("GET", "/v2/categories"))
+
+		badHeaders := map[string]interface{}{
+			// check different upper/lower casings
+			"Authorization": "a",
+			"Content-type": "b",
+			"user-agent": "c",
+		}
+		client.Headers = badHeaders
+
+		client.Categories()
+
+		actualHeaders := server.ReceivedRequests()[0].Header
+
+		authorization := actualHeaders["Authorization"][0]
+		contentType := actualHeaders["Content-Type"][0]
+		userAgent := actualHeaders["User-Agent"][0]
+
+		Expect(authorization).NotTo(Equal("a"))
+		Expect(contentType).NotTo(Equal("b"))
+		Expect(userAgent).NotTo(Equal("c"))
 	})
 })

--- a/test/Headers_test.go
+++ b/test/Headers_test.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/taxjar/taxjar-go"
+)
+
+var _ = Describe("Request headers:", func() {
+	RegisterFailHandler(Fail)
+	defer GinkgoRecover()
+
+	var server *ghttp.Server
+	var client taxjar.Config
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		client = taxjar.NewClient(taxjar.Config{
+			APIKey: "test123",
+			APIURL: server.URL(),
+		})
+	})
+
+	It("should include all appropriate headers", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/v2/categories"),
+			ghttp.VerifyContentType("application/json"),
+			ghttp.VerifyHeader(http.Header{
+				"Authorization": []string{"Bearer test123"},
+			}),
+		))
+		client.Categories()
+
+		userAgent := server.ReceivedRequests()[0].Header["User-Agent"][0]
+		Expect(userAgent).To(MatchRegexp(`^TaxJar/Go \(.*\) taxjar-go/\d+\.\d+\.\d+$`))
+	})
+})

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package taxjar
+
+const version = "1.0.0"


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Go version
- Version of taxjar-go currently being used

Example UA string:
<img width="996" alt="Screen Shot 2020-03-20 at 8 47 52 AM" src="https://user-images.githubusercontent.com/26824724/77180763-9f105b80-6a87-11ea-9de1-fbd287cb192f.png">
