### PR TITLE
Change OrderLineItem.ID from json.Number to string

### DIFF
--- a/ShowOrder.go
+++ b/ShowOrder.go
@@ -18,14 +18,14 @@ type ShowOrderResponse struct {
 //
 // OrderLineItem is also the structure for a line item returned within `CreateOrderResponse.Order.LineItems`, `UpdateOrderResponse.Order.LineItems`, `ShowOrderResponse.Order.LineItems`, and `DeleteOrderResponse.Order.LineItems`․
 type OrderLineItem struct {
-	ID                json.Number `json:"id,omitempty"`
-	Quantity          int         `json:"quantity,omitempty"`
-	ProductIdentifier string      `json:"product_identifier,omitempty"`
-	Description       string      `json:"description,omitempty"`
-	ProductTaxCode    string      `json:"product_tax_code,omitempty"`
-	UnitPrice         float64     `json:"unit_price,omitempty,string"`
-	Discount          float64     `json:"discount,omitempty,string"`
-	SalesTax          float64     `json:"sales_tax,omitempty,string"`
+	ID                string  `json:"id,omitempty"`
+	Quantity          int     `json:"quantity,omitempty"`
+	ProductIdentifier string  `json:"product_identifier,omitempty"`
+	Description       string  `json:"description,omitempty"`
+	ProductTaxCode    string  `json:"product_tax_code,omitempty"`
+	UnitPrice         float64 `json:"unit_price,omitempty,string"`
+	Discount          float64 `json:"discount,omitempty,string"`
+	SalesTax          float64 `json:"sales_tax,omitempty,string"`
 }
 
 // ShowOrder shows an existing order in TaxJar․

--- a/test/mocks/CreateOrder_mock.go
+++ b/test/mocks/CreateOrder_mock.go
@@ -35,7 +35,7 @@ var CreateOrderJSON = `{
     "sales_tax": "0.0",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",

--- a/test/mocks/CreateRefund_mock.go
+++ b/test/mocks/CreateRefund_mock.go
@@ -35,7 +35,7 @@ var CreateRefundJSON = `{
     "sales_tax": "-10.3",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",
@@ -45,7 +45,7 @@ var CreateRefundJSON = `{
         "sales_tax": "0.0"
       },
       {
-        "id": 1,
+        "id": "1",
         "quantity": 1,
         "product_identifier": "78-95432-101",
         "product_tax_code": "20010",

--- a/test/mocks/ShowOrder_mock.go
+++ b/test/mocks/ShowOrder_mock.go
@@ -35,7 +35,7 @@ var ShowOrderJSON = `{
     "sales_tax": "0.0",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",

--- a/test/mocks/ShowRefund_mock.go
+++ b/test/mocks/ShowRefund_mock.go
@@ -35,7 +35,7 @@ var ShowRefundJSON = `{
     "sales_tax": "-10.3",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",
@@ -45,7 +45,7 @@ var ShowRefundJSON = `{
         "sales_tax": "0.0"
       },
       {
-        "id": 1,
+        "id": "1",
         "quantity": 1,
         "product_identifier": "78-95432-101",
         "product_tax_code": "20010",

--- a/test/mocks/UpdateOrder_mock.go
+++ b/test/mocks/UpdateOrder_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"encoding/json"
+
 	"github.com/taxjar/taxjar-go"
 )
 
@@ -34,7 +35,7 @@ var UpdateOrderJSON = `{
     "sales_tax": "10.3",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",
@@ -44,7 +45,7 @@ var UpdateOrderJSON = `{
         "sales_tax": "0.0"
       },
       {
-        "id": 1,
+        "id": "1",
         "quantity": 1,
         "product_identifier": "78-95432-101",
         "product_tax_code": "20010",

--- a/test/mocks/UpdateRefund_mock.go
+++ b/test/mocks/UpdateRefund_mock.go
@@ -35,7 +35,7 @@ var UpdateRefundJSON = `{
     "sales_tax": "-10.3",
     "line_items": [
       {
-        "id": 0,
+        "id": "0",
         "quantity": 1,
         "product_identifier": "10-12345-987",
         "product_tax_code": "20010",
@@ -45,7 +45,7 @@ var UpdateRefundJSON = `{
         "sales_tax": "0.0"
       },
       {
-        "id": 1,
+        "id": "1",
         "quantity": 1,
         "product_identifier": "78-95432-101",
         "product_tax_code": "20010",


### PR DESCRIPTION
According to the documentation `line_items[][id]` should be a string and "Unique identifier of the given line item."
- https://developers.taxjar.com/api/reference/?go#get-show-an-order-transaction
![show order](https://user-images.githubusercontent.com/894998/184119047-d5f7966e-b2a7-41e3-8fef-5fe09cd686c7.png)

Forcing it be a numeric string is problematic. For instance, the platform I'm integrating with uses UUIDs for line item ids.
For example:
```
json: invalid number literal, trying to unmarshal "\"7a921b38-e22c-4243-9c23-c60d9abddffa\"" into Number
    occurred
```

