### PR TITLE
Handle API line item numeric strings in json.Unmarshal

### DIFF
--- a/CreateOrder.go
+++ b/CreateOrder.go
@@ -67,7 +67,14 @@ func (client *Config) CreateOrder(params CreateOrderParams) (*CreateOrderRespons
 
 	order := new(CreateOrderResponse)
 	if err := json.Unmarshal(res.([]byte), &order); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "order.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return order, nil

--- a/CreateRefund.go
+++ b/CreateRefund.go
@@ -44,7 +44,14 @@ func (client *Config) CreateRefund(params CreateRefundParams) (*CreateRefundResp
 
 	refund := new(CreateRefundResponse)
 	if err := json.Unmarshal(res.([]byte), &refund); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "refund.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return refund, nil

--- a/DeleteOrder.go
+++ b/DeleteOrder.go
@@ -30,7 +30,14 @@ func (client *Config) DeleteOrder(transactionID string, params ...DeleteOrderPar
 
 	order := new(DeleteOrderResponse)
 	if err := json.Unmarshal(res.([]byte), &order); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "order.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return order, nil

--- a/DeleteRefund.go
+++ b/DeleteRefund.go
@@ -30,7 +30,14 @@ func (client *Config) DeleteRefund(transactionID string, params ...DeleteRefundP
 
 	refund := new(DeleteRefundResponse)
 	if err := json.Unmarshal(res.([]byte), &refund); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "refund.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return refund, nil

--- a/ShowOrder.go
+++ b/ShowOrder.go
@@ -44,8 +44,14 @@ func (client *Config) ShowOrder(transactionID string, params ...ShowOrderParams)
 
 	order := new(ShowOrderResponse)
 	if err := json.Unmarshal(res.([]byte), &order); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "order.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
-
 	return order, nil
 }

--- a/ShowRefund.go
+++ b/ShowRefund.go
@@ -49,7 +49,14 @@ func (client *Config) ShowRefund(transactionID string, params ...ShowRefundParam
 
 	refund := new(ShowRefundResponse)
 	if err := json.Unmarshal(res.([]byte), &refund); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "refund.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return refund, nil

--- a/UpdateOrder.go
+++ b/UpdateOrder.go
@@ -42,7 +42,14 @@ func (client *Config) UpdateOrder(params UpdateOrderParams) (*UpdateOrderRespons
 
 	order := new(UpdateOrderResponse)
 	if err := json.Unmarshal(res.([]byte), &order); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "order.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return order, nil

--- a/UpdateRefund.go
+++ b/UpdateRefund.go
@@ -43,7 +43,14 @@ func (client *Config) UpdateRefund(params UpdateRefundParams) (*UpdateRefundResp
 
 	refund := new(UpdateRefundResponse)
 	if err := json.Unmarshal(res.([]byte), &refund); err != nil {
-		return nil, err
+		if typeError, ok := err.(*json.UnmarshalTypeError); ok {
+			// Ignores JSON line_item.id type errors due to API's conversion of numeric strings to integers
+			if !(typeError.Field == "refund.line_items.id" && typeError.Value == "number") {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return refund, nil

--- a/test/LiveToken_test.go
+++ b/test/LiveToken_test.go
@@ -198,10 +198,11 @@ var _ = Describe("using a live/sandbox token", func() {
 	})
 
 	Context("UpdateOrder", func() {
-		It("udpates an order", func() {
+		It("updates an order", func() {
 			res, err := client.UpdateOrder(taxjar.UpdateOrderParams{
 				TransactionID: "24",
 				Amount:        161,
+				Shipping:      5,
 				SalesTax:      10.3,
 				LineItems: []taxjar.OrderLineItem{
 					{
@@ -305,6 +306,7 @@ var _ = Describe("using a live/sandbox token", func() {
 			res, err := client.UpdateRefund(taxjar.UpdateRefundParams{
 				TransactionID:          "24-refund",
 				TransactionReferenceID: "24",
+				Amount:                 -116,
 				Shipping:               -5,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/Methods_test.go
+++ b/test/Methods_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Method:", func() {
 	})
 
 	Context("UpdateOrder", func() {
-		It("udpates an order", func() {
+		It("updates an order", func() {
 			server.AppendHandlers(ghttp.CombineHandlers(
 				ghttp.VerifyRequest("PUT", "/v2/transactions/orders/24"),
 				ghttp.RespondWith(http.StatusOK, mocks.UpdateOrderJSON),


### PR DESCRIPTION
### Context
Although the TaxJar API accepts line item IDs of type `string`, when a numeric string is encountered, the corresponding response line item ID is returned as an `integer` rather than the request body's type of `string`.

When this error was previously identified, the accepted resolution in PR #8 was to modify the underlying `OrderLineItem` struct to decode ID values as `json.Number` rather than `string`, since the JSON number literal type will accept numeric string values.

While this change addressed the API's potential internal modification of ID value types, it did not account for the possibility of special characters (or letters) being included in item identifiers as raised in Issue #16.

### Description
If a type error is encountered when `Unmarshal`-ing transaction request JSON and that type error is due to a numeric line item ID in the API response, we will no longer return an error. This will still surface all other errors, including other type errors on this field.

### Testing
- "Live"-token Order and Refund CRUD tests were failing due to Unmarshal error prior to these changes, but are no longer.
- Additionally, UpdateOrder and UpdateRefund live tests had to be modified to account for API updates that include the requirement that shipping amount be included in the request body grand total amount.

#### WIth API key set in environment (live mode)
<img width="419" alt="Screen Shot 2022-10-14 at 10 35 49 PM" src="https://user-images.githubusercontent.com/47947793/195968830-ea7430ad-0bdf-471a-af3d-230f8fd280f2.png">

#### Without API key set in environment
<img width="425" alt="Screen Shot 2022-10-14 at 10 36 22 PM" src="https://user-images.githubusercontent.com/47947793/195968841-7770b4b4-cf7a-4b8b-b00a-699212c07dbc.png">
